### PR TITLE
Set charter adoption date to 1 Feb 2024

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -2,7 +2,7 @@
 
 ## End User Working Group
 
-### Adopted [tbd]
+### Adopted 7 January, 2024
 
 This Technical Charter sets forth the responsibilities and procedures for technical contribution to, and oversight of, the OpenSSF End User Working Group open source community, which has been established as a Working Group (the "Technical Initiative") under the Open Source Security Foundation (the “OpenSSF”).  All contributors (including committers, maintainers, and other technical positions) and other participants in the Technical Initiative (collectively, “Collaborators”) must comply with the terms of this Technical Charter and the OpenSSF Charter. 
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -2,7 +2,7 @@
 
 ## End User Working Group
 
-### Adopted 7 January, 2024
+### Adopted 1 February, 2024
 
 This Technical Charter sets forth the responsibilities and procedures for technical contribution to, and oversight of, the OpenSSF End User Working Group open source community, which has been established as a Working Group (the "Technical Initiative") under the Open Source Security Foundation (the “OpenSSF”).  All contributors (including committers, maintainers, and other technical positions) and other participants in the Technical Initiative (collectively, “Collaborators”) must comply with the terms of this Technical Charter and the OpenSSF Charter. 
 


### PR DESCRIPTION
Due to administrative oversight, the End Users WG has never formally adopted a charter. This PR proposes a date on which the charter is to be considered to be adopted, allowing time for folks on holidays and returning in the new year to add their +1s.